### PR TITLE
🛠️ Refactor: Format abbreviations and introduce conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Project Conventions
+
+## General Rules
+- Clean Code Formatting: Always use one command per line to reduce cognitive load and improve readability (following Robert C. Martin's principles).
+- Vim Mappings: Prefer non-recursive abbreviations (`cnoreabbrev` over `cab`, `nnoremap` over `nmap`, etc.) for safety to prevent infinite loops.
+
+## Operational Memory
+- `plugin/` -> Vim plugin entrypoints and global configuration.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tasks.ci]
+run = "echo 'ci pass'"
+
+[tasks.test]
+run = "echo 'test pass'"

--- a/plugin/yescapsquit.vim
+++ b/plugin/yescapsquit.vim
@@ -1,2 +1,12 @@
-cab W w| cab Q q| cab Wq wq| cab wQ wq| cab WQ wq
+" Map uppercase commands to their lowercase equivalents to avoid frustration
+" when saving and quitting while accidentally holding shift.
+" We use cnoreabbrev (non-recursive) instead of cab (recursive) for safety
+" and avoid multiple statements per line for readability.
+cnoreabbrev W w
+cnoreabbrev Q q
+cnoreabbrev Wq wq
+cnoreabbrev wQ wq
+cnoreabbrev WQ wq
+
+" Quickly enter command mode
 nnoremap ; :


### PR DESCRIPTION
### Assumptions
- I assumed it's best to configure basic `ci` and `test` tasks in `mise.toml` using simple `echo` commands since there is no test runner currently present.
- I assumed the user wants the new `AGENTS.md` file to follow the standard conventions mapping patterns in Vim as described in clean code principles.

### Alternatives Not Chosen
- I considered keeping the `cab` recursive abbreviation and simply making it multiline, but changed it to `cnoreabbrev` as per best practices in Vim script to avoid unintended recursive loops.
- I considered extracting the mappings into a separate configuration file, but that would overcomplicate the current scope given it's a small script file.

### How To Pivot
- If `mise.toml` is unnecessary, the smallest concrete change needed to redirect the PR is to remove `mise.toml` and drop the requirement in the `AGENTS.md` file if the project decides not to adopt `mise` for testing at this time.

### Next Knobs
- To configure proper testing, update `run = "echo 'test pass'"` to the actual unit test script in `mise.toml`.
- You can add more Vim script conventions to `AGENTS.md` to establish strict guidelines as the project grows.

---
*PR created automatically by Jules for task [14221998673868478418](https://jules.google.com/task/14221998673868478418) started by @lucasew*